### PR TITLE
Added Opening Soon and Close Soon facilities to relevant searches

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -89,6 +89,9 @@ class Facility < ActiveRecord::Base
 		ulat = ulat.to_d
 		ulong = ulong.to_d
 
+		# Using 30 mins delay to show "Opening Soon" and "Closing Soon" facilities.
+		ctime = Facility.adjusted_current_time + 30.minutes
+
 		# First query db for any verified facility whose services contains the service_query
 		#   and store in searched_facilities
 		searched_facilities = Facility.search_by_services(service_query).is_verified
@@ -97,11 +100,11 @@ class Facility < ActiveRecord::Base
 		selected_facilities = Array.new
 		searched_facilities.each do |facility|
 			if (open=="Yes")
-				if facility.is_open?
+				if facility.is_open?(ctime)
 					selected_facilities.push facility
 				end
 			elsif (open=="No")
-				if facility.is_closed?
+				if facility.is_closed?(ctime)
 					selected_facilities.push facility
 				end
 			else


### PR DESCRIPTION
Researching for the logic behind Open, Close, Opening Soon and Closing Soon facilities:
1) Currently, timezone is hardcoded as UTC-8h. It introduces a problem because Vancouver time fluctuates around UTC depending on the season. For example, Vancouver is currently set as UTC-7h.
2) The current logic for "Opening Soon"/"Closing Soon" uses a window of 30min.

Therefore, this fixes introduces a delay of 30 minutes to searches for Facilities to add Opening soon and closing soon facilities to relevant searches. Future refactor will be needed to use timezone (PST).

Trello Card:
https://trello.com/c/RHrHSd3s