### PR TITLE
Implements the COVID-19 notice place.

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,10 +1,19 @@
 class NoticesController < ApplicationController
-  before_action :require_signin, except: [:list, :view]
-  before_action :require_admin, except: [:list, :view]
+  before_action :require_signin, except: [:list, :view, :covid19]
+  before_action :require_admin, except: [:list, :view, :covid19]
 
   def index
 		@notices = Notice.order("id ASC").all
-	end
+  end
+  
+  def covid19
+    @notice = Notice.find_by(notice_type: :covid19)
+    if @notice.present?
+      render :show
+    else
+      redirect_to facilities_path
+    end
+  end
 
   def show
     @notice = Notice.find(params[:id])

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,2 +1,6 @@
 class Notice < ActiveRecord::Base
+  enum notice_type: {
+    general: 'general',
+    covid19: 'covid19'
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,8 +58,13 @@ end #/api
   get 'notices' => 'notices#index'
   get 'notices/list' => 'notices#list'
   get 'notice/:slug' => 'notices#view'
+  # get 'covid19' => 'notices#covid19'
   resources :alerts
-  resources :notices
+  resources :notices do
+    collection do
+      get :covid19
+    end
+  end
   resources :facilities
 
   # match "users/:id/toggle_verify" => "users#toggle_verify"

--- a/db/migrate/20200321192119_add_type_to_notices.rb
+++ b/db/migrate/20200321192119_add_type_to_notices.rb
@@ -1,0 +1,5 @@
+class AddTypeToNotices < ActiveRecord::Migration
+  def change
+    add_column :notices, :notice_type, :string
+  end
+end

--- a/db/migrate/20200321192533_set_type_on_all_notices.rb
+++ b/db/migrate/20200321192533_set_type_on_all_notices.rb
@@ -1,0 +1,7 @@
+class SetTypeOnAllNotices < ActiveRecord::Migration
+  def change
+    Notice.transaction do
+      Notice.all.update_all(notice_type: :general)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190824231458) do
+ActiveRecord::Schema.define(version: 20200321192533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,12 @@ ActiveRecord::Schema.define(version: 20190824231458) do
     t.decimal  "long"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "ar_internal_metadata", primary_key: "key", force: :cascade do |t|
+    t.string   "value"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "facilities", force: :cascade do |t|
@@ -166,8 +172,9 @@ ActiveRecord::Schema.define(version: 20190824231458) do
     t.string   "slug"
     t.text     "content"
     t.boolean  "published"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.string   "notice_type"
   end
 
   create_table "statuses", force: :cascade do |t|


### PR DESCRIPTION
- Implements the COVID-19 notice place.
- Adds notice_type field to Notice model as an enum.
- Also implements a route to 'notices/covid19' , internally named 'covid19_notices_path'.
